### PR TITLE
Add SSR-safe portal guard and regression test for Toaster

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "node --test tests/*.test.mjs"
   },
   "keywords": [
     "react",

--- a/src/lib/Toaster.tsx
+++ b/src/lib/Toaster.tsx
@@ -25,6 +25,7 @@ export function Toaster({
                             richColor = false,
                         }: CustomProps) {
     const [toasts, setToasts] = useState<ToastProps[]>([]);
+    const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
     const {initial, animate, exit} = getToastAnimation(position);
     const positionValue = getPosition(position);
 
@@ -39,8 +40,16 @@ export function Toaster({
         return unsubscribe;
     }, []);
     useEffect(() => {
+        setPortalTarget(document.body);
+    }, []);
+
+    useEffect(() => {
         injectStyles()
     }, [])
+
+    if (!portalTarget) {
+        return null;
+    }
 
     return createPortal(
         <div
@@ -61,6 +70,6 @@ export function Toaster({
                 ))}
             </AnimatePresence>
         </div>,
-        document.body
+        portalTarget
     );
 }

--- a/tests/toaster-ssr-guard.test.mjs
+++ b/tests/toaster-ssr-guard.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+
+const toasterSource = readFileSync(new URL('../src/lib/Toaster.tsx', import.meta.url), 'utf8');
+
+test('Toaster defers portal target assignment until after mount', () => {
+  assert.match(
+    toasterSource,
+    /const \[portalTarget, setPortalTarget\] = useState<HTMLElement \| null>\(null\);/
+  );
+  assert.match(toasterSource, /setPortalTarget\(document\.body\);/);
+  assert.match(toasterSource, /if \(!portalTarget\) \{\s*return null;\s*\}/s);
+});
+
+test('Toaster does not pass document.body directly to createPortal', () => {
+  assert.doesNotMatch(toasterSource, /createPortal\([\s\S]*document\.body\s*\)/);
+  assert.match(toasterSource, /createPortal\([\s\S]*portalTarget\s*\)/);
+});


### PR DESCRIPTION
### Motivation
- Prevent server-side rendering errors caused by accessing `document.body` during SSR by deferring portal target assignment until after mount and adding a regression test to catch regressions.

### Description
- In `src/lib/Toaster.tsx` added a `portalTarget` state, an effect that sets it to `document.body` after mount, an early-return guard while it is `null`, and switched `createPortal` to use `portalTarget` instead of `document.body`.
- Added `tests/toaster-ssr-guard.test.mjs` which asserts the component initializes `portalTarget` as `null`, sets it in an effect, guards rendering with `return null`, and does not pass `document.body` directly to `createPortal`.
- Added a `test` script to `package.json` that runs Node's built-in test runner with `node --test tests/*.test.mjs`.

### Testing
- Ran `npm test` which executed the two regression tests and both passed.
- Ran `npm run lint` (ESLint) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c47448ea48333a5d04d44becb3f3d)